### PR TITLE
Hook for xmldiff

### DIFF
--- a/PyInstaller/hooks/hook-xmldiff.py
+++ b/PyInstaller/hooks/hook-xmldiff.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# Tested with xmldiff v2.4.
+# Hook for https://github.com/Shoobx/xmldiff
+
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('xmldiff')


### PR DESCRIPTION
Created for the latest xmldiff version 2.4

Required due how xmldiff uses pkg_resources.require("xmldiff")[0].version in their main.py

Tested on Windows 10 latest non insider builds.

https://github.com/Shoobx/xmldiff